### PR TITLE
Update bloomreach_generics.py

### DIFF
--- a/src/bloomreach_generics.py
+++ b/src/bloomreach_generics.py
@@ -30,7 +30,7 @@ def create_product(shopify_product, pid_identifiers = None, vid_identifiers = No
     #   attributes["sp." + prop] = v
 
   return {
-    "id": create_id(shopify_product, identifiers=pid_identifiers), 
+    "id": shopify_product["id"].split('/')[-1], 
     "attributes": create_attributes(shopify_product, "sp"), 
     "variants": create_variants(shopify_product, identifiers=vid_identifiers)
     }

--- a/src/bloomreach_products.py
+++ b/src/bloomreach_products.py
@@ -9,7 +9,8 @@ logger = logging.getLogger(__name__)
 PRODUCT_MAPPINGS = [
   ["sp.vendor", "brand", lambda x: x],
   ["sp.descriptionHtml", "description", lambda x: x.strip()],
-  ["sp.title", "title", lambda x: x]
+  ["sp.title", "title", lambda x: x],
+  ["sp.priceRangeV2", "maxVariantPrice", lambda x: x["maxVariantPrice"]["amount"]]
 ]
 
 


### PR DESCRIPTION
This is an example demonstrating how you could explicitly set the identifier used throughout the rest of the processing steps to be the trailing numeric value of a shopify object id.