### PR TITLE
Bump Shopify api version to latest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ jsonlines==3.1.0
 polling==0.3.2
 pyactiveresource==2.2.2
 PyJWT==2.6.0
-PyYAML==6.0
+PyYAML==6.0.2
 requests==2.28.1
 ShopifyAPI==12.7.0
 six==1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ pyactiveresource==2.2.2
 PyJWT==2.6.0
 PyYAML==6.0
 requests==2.28.1
-ShopifyAPI==12.1.0
+ShopifyAPI==12.7.0
 six==1.16.0
 urllib3==1.26.13

--- a/src/graphql.py
+++ b/src/graphql.py
@@ -61,6 +61,7 @@ def export_jsonl(context):
     logger.info("GraphQL Bulk Operation not submitted, trying again after delay. Another operation already in progress: %s", result_json)
     return False
   else:
+    logger.error(result_json)
     raise RuntimeError("Unable to start ExportDataJob")
 
 

--- a/src/graphql.py
+++ b/src/graphql.py
@@ -187,4 +187,4 @@ if __name__ == '__main__':
   shopify_pat = args.shopify_pat
   output_dir = args.output_dir
 
-  get_shopify_jsonl_fp(shopify_url, '2022-04', shopify_pat, output_dir)
+  get_shopify_jsonl_fp(shopify_url, '2025-04', shopify_pat, output_dir)

--- a/src/graphql_queries/export_data_job.graphql
+++ b/src/graphql_queries/export_data_job.graphql
@@ -87,7 +87,6 @@ mutation ExportDataJob {
                                             value
                                         }
                                         compareAtPrice
-                                        weight
                                         inventoryQuantity
                                         availableForSale
                                     }

--- a/src/graphql_queries/export_data_job.graphql
+++ b/src/graphql_queries/export_data_job.graphql
@@ -43,7 +43,6 @@ mutation ExportDataJob {
                                         id
                                         handle
                                         title
-                                        productsCount
                                     }
                                 }
                             }

--- a/src/main.py
+++ b/src/main.py
@@ -18,7 +18,7 @@ def main(shopify_url="",
          output_dir=""):
 
   run_num = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
-  api_version = '2022-04'
+  api_version = '2025-04'
   shopify_jsonl_fp, job_id = get_shopify_jsonl_fp(shopify_url, api_version,
                                           shopify_pat, output_dir, run_num=run_num)
 


### PR DESCRIPTION
* Bump Shopify API version to latest -> 2025-04 from 2022-04
* Remove unused property on collections that is no longer compatible with API version (https://shopify.dev/changelog/unification-of-count-fields)
* Removed deprecated weight property from productvariant (https://shopify.dev/changelog/inventory-item-new-fields-and-productvariant-deprecations)